### PR TITLE
Improve logging when syncing fails for better debugging

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,9 +45,10 @@ module.exports = {
                 return new Promise(function(resolve, reject) {
                     Rsync(options, function (error, stdout, stderr, cmd)  {
                         if (error) {
+                            that.log(cmd);
                             that.log(stdout);
                             that.log(stderr);
-                            reject(new SilentError('Unable to sync!'));
+                            reject(new SilentError('Unable to sync! ' + error));
                         } else {
                             that.log(stdout);
                             resolve();


### PR DESCRIPTION
When I first tried to use deploy-rsync it failed but the only error it showed me was 'Unable to sync!'. With only this message it was very hard to figure out what the cause actually was.

So when there is an error I have therefore improved the logging that the command run is logged and also the error itself. Error message contains the return code e.g. 'Error: rsync exited with code 127'.