### PR TITLE
Fix `ember-cli/ext/promise` Deprecation for Ember CLI >=2.12.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 'use strict';
 
 var BasePlugin = require('ember-cli-deploy-plugin');
-var Promise = require('ember-cli/lib/ext/promise');
+var Promise = require('rsvp').Promise;
 var SilentError = require('silent-error');
 var Rsync = require('rsyncwrapper').rsync;
 

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   "dependencies": {
     "core-object": "1.1.0",
     "ember-cli-deploy-plugin": "^0.2.0",
+    "rsvp": "^3.5.0",
     "rsyncwrapper": "0.4.2",
     "silent-error": "^1.0.0"
   }


### PR DESCRIPTION
This resolves the deprecation warning:

```
DEPRECATION: `ember-cli/ext/promise` is deprecated, use `rsvp` instead...
```